### PR TITLE
fix: removed hardcoded aws region

### DIFF
--- a/common/bean.go
+++ b/common/bean.go
@@ -16,6 +16,7 @@ type ScanEvent struct {
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	Token        string `json:"token"`
+	AwsRegion    string `json:"awsRegion"`
 }
 
 type ScanEventResponse struct {

--- a/pkg/klarService/KlarService.go
+++ b/pkg/klarService/KlarService.go
@@ -81,7 +81,7 @@ func (impl *KlarServiceImpl) Process(scanEvent *common.ScanEvent) (*common.ScanE
 	var sess *session.Session
 	if (len(scanEvent.AccessKey) > 0 && len(scanEvent.SecretKey) > 0) || len(scanEvent.Token) > 0 {
 		sess, err = session.NewSession(&aws.Config{
-			Region:      aws.String("us-east-2"),
+			Region:      aws.String(scanEvent.AwsRegion),
 			Credentials: credentials.NewStaticCredentials(scanEvent.AccessKey, scanEvent.SecretKey, scanEvent.Token),
 		})
 	}
@@ -90,7 +90,7 @@ func (impl *KlarServiceImpl) Process(scanEvent *common.ScanEvent) (*common.ScanE
 	tokenData := ""
 	tokens := &tokenData
 	if (len(scanEvent.AccessKey) > 0 && len(scanEvent.SecretKey) > 0) || len(scanEvent.Token) > 0 {
-		svc := ecr.New(sess, aws.NewConfig().WithRegion("us-east-2"))
+		svc := ecr.New(sess, aws.NewConfig().WithRegion(scanEvent.AwsRegion))
 		token, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

aws region fixed as of now in image scanning service, passed it from devtron and ci runner to image scanner. 

Fixes # (issue) : https://github.com/devtron-labs/devtron/issues/650

Linked # (PR) : https://github.com/devtron-labs/devtron/pull/657,  https://github.com/devtron-labs/ci-runner/pull/15

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Aws region received in event payload passed.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles