### PR TITLE
nats client logging added

### DIFF
--- a/client/NatClient.go
+++ b/client/NatClient.go
@@ -30,13 +30,13 @@ func NewPubSubClient(logger *zap.SugaredLogger) (*PubSubClient, error) {
 	nc, err := nats.Connect(cfg.NatsServerHost,
 		nats.ReconnectWait(10*time.Second), nats.MaxReconnects(100),
 		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-			logger.Errorw("Got disconnected!", "Reason", err)
+			logger.Errorw("Nats Connection got disconnected!", "Reason", err)
 		}),
 		nats.ReconnectHandler(func(nc *nats.Conn) {
-			logger.Infow("Got reconnected", "url", nc.ConnectedUrl())
+			logger.Infow("Nats Connection got reconnected", "url", nc.ConnectedUrl())
 		}),
 		nats.ClosedHandler(func(nc *nats.Conn) {
-			logger.Errorw("Connection closed!", "Reason", nc.LastError())
+			logger.Errorw("Nats Client Connection closed!", "Reason", nc.LastError())
 		}))
 	if err != nil {
 		logger.Error("err", err)


### PR DESCRIPTION
# Description

Logging added for nats client re-connection & disconnection. Would be helpful in debugging any issue. 

Related to devtron-labs/devtron#1873

## Type of change

- [x] Enhancement

# How Has This Been Tested?

- [x] Restarted Nats Server Pod, checked for both disconnection & reconnection logs.