### PR TITLE
Fix: scanning failed due to invalid json output.

### DIFF
--- a/common/bean.go
+++ b/common/bean.go
@@ -3,6 +3,7 @@ package common
 import (
 	"github.com/optiopay/klar/clair"
 	"github.com/quay/claircore"
+	"strings"
 	"time"
 )
 
@@ -123,4 +124,11 @@ type SeverityCount struct {
 	High     int `json:"high"`
 	Moderate int `json:"moderate"`
 	Low      int `json:"low"`
+}
+
+func RemoveTrailingComma(jsonString string) string {
+	if strings.HasSuffix(jsonString, ",]") {
+		return jsonString[:len(jsonString)-2] + jsonString[len(jsonString)-1:]
+	}
+	return jsonString
 }

--- a/pkg/security/ImageScanService.go
+++ b/pkg/security/ImageScanService.go
@@ -379,6 +379,7 @@ func (impl *ImageScanServiceImpl) ConvertEndStepOutputAndSaveVulnerabilities(ste
 		impl.logger.Errorw("error in parsing template to get vulnerabilities", "err", err)
 		return err
 	}
+	renderedTemplate = common.RemoveTrailingComma(renderedTemplate)
 	var vulnerabilities []*bean.ImageScanOutputObject
 	err = json.Unmarshal([]byte(renderedTemplate), &vulnerabilities)
 	if err != nil {


### PR DESCRIPTION
Scanning was failing as we were unmarshalling invalid json into structs in some cases while go templating the output.
We generate json output through the results obtained from trivy through go templating with logic that if it is the last object with last vulnerability, do not append , otherwise do, but in case of last object didnt had vulnerabilities array in json , it created invalid json due to which unmarshalling gave error, have handled the case by removing the trailing comma check.
Fixes : [#4365](https://github.com/devtron-labs/devtron/issues/4365)