### PR TITLE
fix: handle case when Results key is not found in trivy scan report

### DIFF
--- a/internal/step-lib/util/common-util/util.go
+++ b/internal/step-lib/util/common-util/util.go
@@ -61,6 +61,10 @@ func ParseJsonTemplate(inputTemplate string, data []byte) (string, error) {
 		return "", err
 	}
 	buf := &bytes.Buffer{}
+	//this check handles the case when Results key is not found in trivy scan report
+	if _, ok := jsonMap["Results"]; !ok {
+		return "[]", nil
+	}
 	err = tmpl.Execute(buf, jsonMap)
 	if err != nil {
 		log.Println("error in executing template", "err", err)


### PR DESCRIPTION
A specific case has been handled in this pr, when a Trivy scan report can have no Results key on which we are calculating length in our go template

fixes:- https://github.com/devtron-labs/devtron/issues/4719